### PR TITLE
Prefix as Parameter

### DIFF
--- a/celerybeatredis/__init__.py
+++ b/celerybeatredis/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+from .schedulers import PeriodicTask
+
+__all__ = ['PeriodicTask']


### PR DESCRIPTION
I am passing the prefix as a parameter, so that I can use the PeriodicTask class from another place.
It makes creating the key value in redis easy : 

In my case I have a flask REST backend that does : 

`````` python
from celerybeatredis import PeriodicTask
[...]
args = parser.parse(daily_schedule_args, request)

task = PeriodicTask(
  "tasks:daily:",
  args['name'],
  args['task'],
  PeriodicTask.Crontab(args['minute'], args['hour'], "*", "*", "*"),
  key=None,
  enabled=args['enable'],
  task_args=args['args'],
  task_kwargs=args['kwargs']
)
task.save()

̀̀̀̀```
``````
