### PR TITLE
Changes to use periodic task from a different python code to write into redis

### DIFF
--- a/celerybeatredis/__init__.py
+++ b/celerybeatredis/__init__.py
@@ -2,4 +2,6 @@ from __future__ import absolute_import
 
 from .schedulers import PeriodicTask
 
-__all__ = ['PeriodicTask']
+__all__ = [
+    'PeriodicTask'
+]

--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -244,6 +244,7 @@ class RedisScheduleEntry(ScheduleEntry):
 
     def is_due(self):
         if not self._task.enabled:
+            get_logger(__name__).info('task %s disabled', self.name)
             return False, 5.0  # 5 second delay for re-enable.
         return self.schedule.is_due(self.last_run_at)
 

--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -40,8 +40,6 @@ class PeriodicTask(object):
     interval = None
     crontab = None
 
-    estimated_duration = 900
-
     args = []
     kwargs = {}
 
@@ -63,7 +61,7 @@ class PeriodicTask(object):
 
     no_changes = False
 
-    def __init__(self, name, task, schedule, key, estimated_duration=None, queue='celery', enabled=True, task_args=[], task_kwargs={}, **kwargs):
+    def __init__(self, name, task, schedule, key, queue='celery', enabled=True, task_args=[], task_kwargs={}, **kwargs):
         self.task = task
         self.enabled = enabled
         if isinstance(schedule, self.Interval):
@@ -71,8 +69,6 @@ class PeriodicTask(object):
         if isinstance(schedule, self.Crontab):
             self.crontab = schedule
 
-        self.estimated_duration = estimated_duration  # duration is needed only by frontend ( backend will execute asap )
-                                                      # -> better to move it frontend storage class ( child of periodic task ? )??
         self.queue = queue
 
         self.args = task_args

--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -40,6 +40,8 @@ class PeriodicTask(object):
     interval = None
     crontab = None
 
+    estimated_duration = 900
+
     args = []
     kwargs = {}
 
@@ -61,13 +63,18 @@ class PeriodicTask(object):
 
     no_changes = False
 
-    def __init__(self, prefix, name, task, schedule, key, enabled=True, task_args=[], task_kwargs={}, **kwargs):
+    def __init__(self, prefix, name, task, schedule, key, estimated_duration=None, queue='celery', enabled=True, task_args=[], task_kwargs={}, **kwargs):
         self.task = task
         self.enabled = enabled
         if isinstance(schedule, self.Interval):
             self.interval = schedule
         if isinstance(schedule, self.Crontab):
             self.crontab = schedule
+
+        self.estimated_duration = estimated_duration  # duration is needed only by frontend ( backend will execute asap )
+                                                      # -> better to move it frontend storage class ( child of periodic task ? )??
+        self.queue = queue
+
         self.args = task_args
         self.kwargs = task_kwargs
 
@@ -245,7 +252,7 @@ class RedisScheduleEntry(ScheduleEntry):
         )
 
     def reserve(self, entry):
-        new_entry = Scheduler.reserve(self, entry)
+        new_entry = Scheduler.reserve(entry)
         return new_entry
 
     def save(self):


### PR DESCRIPTION
- Simplifying prefix / key / name usage in redis task
- Adding possibility to specify queue when creating the periodic task.

Please let me know if anything seems wrong / strange here. Or if another change should be done ( extracting PeriodicTask into a separate file ? )

I would like to polish this redis scheduler, and try to get it integrated in celery contrib since now celery supports redis by default...
