### PR TITLE
Added bytes_to_str() to support PY3.

### DIFF
--- a/celerybeatredis/globals.py
+++ b/celerybeatredis/globals.py
@@ -5,6 +5,7 @@
 # use this file except in compliance with the License. You may obtain a copy
 # of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+import sys
 from redis.client import StrictRedis
 from celery import current_app
 from celery.utils.log import get_logger
@@ -17,3 +18,19 @@ Couldn't add entry %r to redis schedule: %r. Contents: %r
 """
 
 logger = get_logger(__name__)
+
+PY3 = sys.version_info >= (3, 0)
+
+default_encoding = 'utf-8'
+def bytes_to_str(s):
+    if PY3:
+        if isinstance(s, bytes):
+            return s.decode(default_encoding)
+    return s
+
+def str_to_bytes(s):
+    if PY3:
+        if isinstance(s, str):
+            return s.encode(default_encoding)
+    return s
+

--- a/celerybeatredis/task.py
+++ b/celerybeatredis/task.py
@@ -15,7 +15,7 @@ except ImportError:
 import celery.schedules
 
 from .decoder import DateTimeDecoder, DateTimeEncoder
-from .globals import rdb
+from .globals import rdb, bytes_to_str, default_encoding
 
 
 class PeriodicTask(object):
@@ -119,7 +119,7 @@ class PeriodicTask(object):
         tasks = rdb.keys(key_prefix + '*')
         for task_key in tasks:
             try:
-                dct = json.loads(rdb.get(task_key), cls=DateTimeDecoder)
+                dct = json.loads(bytes_to_str(rdb.get(task_key)), cls=DateTimeDecoder, encoding=default_encoding)
                 # task name should always correspond to the key in redis to avoid
                 # issues arising when saving keys - we want to add information to
                 # the current key, not create a new key


### PR DESCRIPTION
With Python 3, getting a value from redis return `bytes` object instead of `str` and we should pass `str` object to `json.loads`.

So this tiny problem makes me hesitate to try out celerybeatredis today.
Here's a PR for that.

Thanks for your nice work!
