### PR TITLE
Fix delete

### DIFF
--- a/celerybeatredis/task.py
+++ b/celerybeatredis/task.py
@@ -15,6 +15,7 @@ except ImportError:
 import celery.schedules
 
 from .decoder import DateTimeDecoder, DateTimeEncoder
+from .exceptions import ValidationError
 from .globals import rdb, bytes_to_str, default_encoding
 
 
@@ -129,7 +130,7 @@ class PeriodicTask(object):
                 logger.warning('ERROR Reading task value at %s', task_key)
 
     def delete(self):
-        rdb.delete(self.name)
+        rdb.set('deleted:' + self.key, 'deleted')
 
     def save(self):
         # must do a deepcopy

--- a/celerybeatredis/task.py
+++ b/celerybeatredis/task.py
@@ -16,7 +16,7 @@ import celery.schedules
 
 from .decoder import DateTimeDecoder, DateTimeEncoder
 from .exceptions import ValidationError
-from .globals import rdb, bytes_to_str, default_encoding
+from .globals import rdb, bytes_to_str, default_encoding, logger
 
 
 class PeriodicTask(object):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
     install_requires=[
         'setuptools',
         'redis',
-        'celery'
+        'celery',
+        'simplejson',
     ]
 
 )


### PR DESCRIPTION
This should fix #8 

The scheduler was holding on to old copies of entries, so if you called delete on a periodic task in between celery beat syncs it would reinsert the deleted keys into redis. This should prevent that behavior.
