### PR TITLE
Lock ttl

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,25 @@ similar to how other aspects of Celery are configured
     CELERY_REDIS_SCHEDULER_URL = "redis://localhost:6379/1"
     CELERY_REDIS_SCHEDULER_KEY_PREFIX = 'tasks:meta:'
 
-You mush make these two value configured. `CELERY_REDIS_SCHEDULER_URL` is used
-to store tasks. `CELERY_REDIS_SCHEDULER_KEY_PREFIX` is used to generate keys in
-redis. The key was like
+You must make sure these two values are configured. `CELERY_REDIS_SCHEDULER_URL`
+is used to store tasks. `CELERY_REDIS_SCHEDULER_KEY_PREFIX` is used to generate
+keys in redis. The keys will be of the form
 
     tasks:meta:task-name-here
     tasks:meta:test-fib-every-3s
+
+There is also an optional setting 
+
+    CELERY_REDIS_SCHEDULER_LOCK_TTL = 30
+
+This value determines how long the redis scheduler will hold on to it's lock,
+which prevents multiple beat instances from running at the same time. However,
+in some cases -- such as a hard crash -- celery beat will not be able to clean
+up after itself and release the lock. Therefore, the lock is given a
+configurable time-to-live, after which it will expire and be released, if it is
+not renewed by the beat instance that acquired it. If said beat instance does
+die, another instance will be able to pick up the baton, as it were, and run
+instead.
 
 # Quickstart
 

--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -132,12 +132,23 @@ class RedisScheduler(Scheduler):
             logger.info('backend scheduler using %s',
                                       current_app.conf.CELERY_REDIS_SCHEDULER_URL)
 
+        # how long we should hold on to the redis lock in seconds
+        if 'CELERY_REDIS_SCHEDULER_LOCK_TTL' in current_app.conf:
+            lock_ttl = current_app.conf.CELERY_REDIS_SCHEDULER_LOCK_TTL
+        else:
+            lock_ttl = 30
+
+        if lock_ttl < self.UPDATE_INTERVAL.seconds:
+            lock_ttl = self.UPDATE_INTERVAL.seconds * 2
+        self.lock_ttl = lock_ttl
+
         self._schedule = {}
         self._last_updated = None
+        self._lock_acquired = False
         Scheduler.__init__(self, *args, **kwargs)
         self.max_interval = (kwargs.get('max_interval') \
                              or self.app.conf.CELERYBEAT_MAX_LOOP_INTERVAL or 300)
-        self._lock = rdb.lock('celery:beat:task_lock')
+        self._lock = rdb.lock('celery:beat:task_lock', timeout=self.lock_ttl)
         self._lock_acquired = self._lock.acquire(blocking=False)
         self.Entry.scheduler = self
 
@@ -183,6 +194,9 @@ class RedisScheduler(Scheduler):
         if self.requires_update():
             self._schedule = self.get_from_database()
             self._last_updated = datetime.datetime.now()
+            # also extend the lock
+            if self._lock_acquired:
+                self._lock_acquired = rdb.expire(self._lock.name, self.lock_ttl)
         return self._schedule
 
     def sync(self):

--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -158,7 +158,7 @@ class RedisScheduler(Scheduler):
 
         # still cannot get lock
         if not self._lock_acquired:
-            logger.warn('another beat is running, disable this node util it is shutdown')
+            logger.warn('another beat is running, disable this node until it is shutdown')
         return super(RedisScheduler, self).tick()
 
     def get_from_database(self):


### PR DESCRIPTION
This should stop #11 from being a problem. The redis lock will expire after a certain amount of time (which is configurable -- default 30 seconds ) and let another beat take over. 
