### PR TITLE
WIP Refactor to match celery 3.1 API

### DIFF
--- a/celerybeatredis/__init__.py
+++ b/celerybeatredis/__init__.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 
-from .schedulers import PeriodicTask
+from .task import PeriodicTask
+from .schedulers import RedisScheduler, RedisScheduleEntry
 
 __all__ = [
-    'PeriodicTask'
+    'PeriodicTask',
+    'RedisScheduler',
+    'RedisScheduleEntry'
 ]

--- a/celerybeatredis/__init__.py
+++ b/celerybeatredis/__init__.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import
 
-from .task import PeriodicTask
+from .task import PeriodicTask, Crontab, Interval
 from .schedulers import RedisScheduler, RedisScheduleEntry
 
 __all__ = [
     'PeriodicTask',
+    'Crontab',
+    'Interval'
     'RedisScheduler',
     'RedisScheduleEntry'
 ]

--- a/celerybeatredis/globals.py
+++ b/celerybeatredis/globals.py
@@ -8,11 +8,12 @@ from redis.client import StrictRedis
 from celery import current_app
 from celery.utils.log import get_logger
 
-rdb = StrictRedis.from_url(current_app.conf.CELERY_REDIS_SCHEDULER_URL)
-
 ADD_ENTRY_ERROR = """\
 
 Couldn't add entry %r to redis schedule: %r. Contents: %r
 """
 
 logger = get_logger(__name__)
+
+
+

--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -225,7 +225,7 @@ class RedisScheduler(Scheduler):
         # we need to merge it with whatever schedule was set in config, and already installed default tasks
         try:
             s = self.all_as_schedule()
-            logger.info("Schedule: {s}".format(s=s))
+            logger.debug("Schedule: {s}".format(s=s))
             self.merge_inplace(s)
         except Exception as exc:
             logger.error("Exception when getting tasks from {url} : {exc}".format(url=self.schedule_url, exc=exc))

--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -126,9 +126,9 @@ class RedisScheduleEntry(object):
         """See :meth:`~celery.schedule.schedule.is_due`."""
         due = self.schedule.is_due(self.last_run_at)
 
-        logger.info('task {0} due : {1}'.format(self.name, due))
+        logger.debug('task {0} due : {1}'.format(self.name, due))
         if not self.enabled:
-            logger.info('task {0} disabled'.format(self.name))
+            logger.info('task {0} is disabled. not triggered.'.format(self.name))
             # if the task is disabled, we always return false, but the time that
             # it is next due is returned as usual
             return celery.schedulers.schedstate(is_due=False, next=due[1])
@@ -225,7 +225,6 @@ class RedisScheduler(Scheduler):
         # we need to merge it with whatever schedule was set in config, and already installed default tasks
         try:
             s = self.all_as_schedule()
-            logger.debug("Schedule: {s}".format(s=s))
             self.merge_inplace(s)
         except Exception as exc:
             logger.error("Exception when getting tasks from {url} : {exc}".format(url=self.schedule_url, exc=exc))
@@ -233,7 +232,7 @@ class RedisScheduler(Scheduler):
             raise
 
         # displaying the schedule we got from redis
-        logger.info(self.schedule)
+        logger.debug("DB schedule : {0}".format(self.schedule))
 
         # this will call self.maybe_due() to check if any entry is due.
         return super(RedisScheduler, self).tick()

--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -4,24 +4,28 @@
 # use this file except in compliance with the License. You may obtain a copy
 # of the License at http://www.apache.org/licenses/LICENSE-2.0
 import datetime
+from functools import partial
 
 from celery.beat import Scheduler, ScheduleEntry
+from redis import StrictRedis
+
 from celery import current_app
 import celery.schedules
 
 from .task import PeriodicTask
-from .globals import rdb, logger, ADD_ENTRY_ERROR
+from .globals import logger, ADD_ENTRY_ERROR
 
 
 class RedisScheduleEntry(ScheduleEntry):
-    def __init__(self, task):
+    def __init__(self, scheduler_url, task):
         self._task = task
 
+        self.scheduler_url = scheduler_url
         self.app = current_app._get_current_object()
         self.name = self._task.key  # passing key here as the task name is a human use only field.
         self.task = self._task.task
 
-        self.schedule = self._task.schedule
+        self.schedule = partial(self._task.schedule, celery_schedules=celery.schedules)
 
         self.args = self._task.args
         self.kwargs = self._task.kwargs
@@ -49,12 +53,12 @@ class RedisScheduleEntry(ScheduleEntry):
     def next(self):
         self._task.last_run_at = self.app.now()
         self._task.total_run_count += 1
-        return self.__class__(self._task)
+        return self.__class__(self.scheduler_url, self._task)
 
     __next__ = next
 
     def is_due(self):
-        due = self.schedule.is_due(self.last_run_at)
+        due = self.schedule().is_due(self.last_run_at)
         if not self._task.enabled:
             logger.info('task %s disabled', self.name)
             # if the task is disabled, we always return false, but the time that
@@ -65,7 +69,7 @@ class RedisScheduleEntry(ScheduleEntry):
     def __repr__(self):
         return '<RedisScheduleEntry ({0} {1}(*{2}, **{3}) {{4}})>'.format(
             self.name, self.task, self.args,
-            self.kwargs, self.schedule,
+            self.kwargs, self.schedule(),
         )
 
     def reserve(self, entry):
@@ -80,7 +84,7 @@ class RedisScheduleEntry(ScheduleEntry):
         self._task.save()
 
     @classmethod
-    def from_entry(cls, name, skip_fields=('relative', 'options'), **entry):
+    def from_entry(cls, scheduler_url, name, skip_fields=('relative', 'options'), **entry):
         options = entry.get('options') or {}
         fields = dict(entry)
         for skip_field in skip_fields:
@@ -105,7 +109,7 @@ class RedisScheduleEntry(ScheduleEntry):
         fields['exchange'] = options.get('exchange')
         fields['routing_key'] = options.get('routing_key')
         fields['key'] = fields['name']
-        return cls(PeriodicTask.from_dict(fields))
+        return cls(PeriodicTask.from_dict(fields, scheduler_url))
 
 
 class RedisScheduler(Scheduler):
@@ -124,6 +128,8 @@ class RedisScheduler(Scheduler):
                                       current_app.conf.CELERY_REDIS_SCHEDULER_URL)
 
         self._schedule = {}
+        self.scheduler_url = current_app.conf.CELERY_REDIS_SCHEDULER_URL
+        self.rdb = StrictRedis.from_url(self.scheduler_url)
         self._last_updated = None
         Scheduler.__init__(self, *args, **kwargs)
         self.max_interval = (kwargs.get('max_interval') \
@@ -143,16 +149,16 @@ class RedisScheduler(Scheduler):
     def get_from_database(self):
         self.sync()
         d = {}
-        for task in PeriodicTask.get_all(current_app.conf.CELERY_REDIS_SCHEDULER_KEY_PREFIX):
-            t = PeriodicTask.from_dict(task)
-            d[t.key] = RedisScheduleEntry(t)
+        for task in PeriodicTask.get_all(self.scheduler_url, current_app.conf.CELERY_REDIS_SCHEDULER_KEY_PREFIX):
+            t = PeriodicTask.from_dict(task, self.scheduler_url)
+            d[t.key] = self.Entry(self.scheduler_url, t)
         return d
 
     def update_from_dict(self, dict_):
         s = {}
         for name, entry in dict_.items():
             try:
-                s[name] = self.Entry.from_entry(name, **entry)
+                s[name] = self.Entry.from_entry(self.scheduler_url, name, **entry)
             except Exception as exc:
                 error(ADD_ENTRY_ERROR, name, exc, entry)
         self.schedule.update(s)

--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -140,6 +140,17 @@ class RedisScheduleEntry(object):
             call=kombu.utils.reprcall(self.task, self.args or (), self.kwargs or {}),
         )
 
+    def update(self, other):
+        """
+        Update values from another entry.
+        This is used to dynamically update periodic entry from edited redis values
+        Does not update "non-editable" fields
+        Extra arguments will be updated (considered editable)
+        """
+        # Handle delegation properly here
+        self._task.update(other._task)
+        # we should never need to touch the app here
+
     #
     # ScheduleEntry needs to be an iterable
     #

--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -264,7 +264,7 @@ class RedisScheduler(Scheduler):
                 name = self._dirty.pop()
                 _tried.add(name)
                 # Saving the entry back into Redis DB.
-                self.rdb.set(name, self.schedule[name].tojson)
+                self.rdb.set(name, self.schedule[name].jsondump())
         except Exception as exc:
             # retry later
             self._dirty |= _tried

--- a/celerybeatredis/task.py
+++ b/celerybeatredis/task.py
@@ -14,26 +14,84 @@ except ImportError:
 
 from .exceptions import ValidationError
 from .decoder import DateTimeDecoder, DateTimeEncoder
+from .globals import logger
+
+
+class Interval(object):
+
+    def __init__(self, every, period='seconds'):
+        self.every = every
+        # could be seconds minutes hours
+        self.period = period
+
+    # def schedule(self, celery_schedules):
+    #     return celery_schedules.schedule(datetime.timedelta(**{self.period: self.every}))
+
+    @property
+    def period_singular(self):
+        return self.period[:-1]
+
+    def __unicode__(self):
+        if self.every == 1:
+            return 'every {0.period_singular}'.format(self)
+        return 'every {0.every} {0.period}'.format(self)
+
+    # @classmethod
+    # def fromdict(cls, d):
+    #     try:
+    #         return cls(d['every'], d.get('period', None))
+    #     except ValueError as exc:
+    #         raise  # not correct json
+
+
+class Crontab(object):
+
+        def __init__(self, minute, hour, day_of_week, day_of_month, month_of_year):
+            self.minute = minute
+            self.hour = hour
+            self.day_of_week = day_of_week
+            self.day_of_month = day_of_month
+            self.month_of_year = month_of_year
+
+        # def schedule(self, celery_schedules):
+        #     return celery_schedules.crontab(minute=self.minute,
+        #                                     hour=self.hour,
+        #                                     day_of_week=self.day_of_week,
+        #                                     day_of_month=self.day_of_month,
+        #                                     month_of_year=self.month_of_year)
+
+        def __unicode__(self):
+            rfield = lambda f: f and str(f).replace(' ', '') or '*'
+            return '{0} {1} {2} {3} {4} (m/h/d/dM/MY)'.format(
+                rfield(self.minute), rfield(self.hour), rfield(self.day_of_week),
+                rfield(self.day_of_month), rfield(self.month_of_year),
+            )
+
+        # @classmethod
+        # def fromdict(cls, d):
+        #     try :
+        #         return cls(d['minute'], d['hour'], d['day_of_week'], d['day_of_month'], d['month_of_year'])
+        #     except ValueError as exc:
+        #         raise  # not correct json
 
 
 class PeriodicTask(object):
     """
-    Represents a periodic task
+    Represents a periodic task.
+    This follows the celery.beat.ScheduleEntry class design.
+    However it is independent of any celery import, so that any client library can import this module
+    and use it to manipulate periodic tasks into a Redis database, without worrying about all the celery imports.
     """
     name = None
     task = None
 
     type_ = None
 
-    interval = None
-    crontab = None
+    data = None
 
     args = []
     kwargs = {}
-
-    queue = None
-    exchange = None
-    routing_key = None
+    options = {}
 
     # datetime
     expires = None
@@ -49,69 +107,53 @@ class PeriodicTask(object):
 
     no_changes = False
 
-    def __init__(self, scheduler_url, name, task, schedule, key, queue='celery', enabled=True, task_args=[], task_kwargs={}, **kwargs):
+    #TODO : match with celery.beat.SchedulerEntry:__init__() signature
+    def __init__(self, scheduler_url, name, task, schedule, enabled=True, args=(), kwargs=None, options=None,
+                 last_run_at=None, total_run_count=None, **extrakwargs):
+        # TODO : get rid of schduler_url if possible
+        """
+
+        :param scheduler_url: the URL of the redic DB where to find the schedule
+        :param name: name of the task (pretty long one)
+        :param task: taskname ( as in celery : python function name )
+        :param schedule: the schedule. maybe also a dict with all schedule content
+        :param relative: if the schedule time needs to be relative to the interval ( see celery.schedules )
+        :param key: the key of this task
+        :param queue: the queue where to send this task (should be in options)
+        :param enabled: whether this task is enabled or not
+        :param args: args for hte task
+        :param kwargs: kwargs for the task
+        :param options: options for hte task
+        :param last_run_at: lat time the task was run
+        :param total_run_count: total number of times the task was run
+        :return:
+        """
+
         self.task = task
         self.enabled = enabled
-        if isinstance(schedule, self.Interval):
-            self.interval = schedule
-        if isinstance(schedule, self.Crontab):
-            self.crontab = schedule
 
-        self.queue = queue
+        # Using schedule property conversion
+        logger.warn("Schedule in Task init {s}".format(s=schedule))
+        self.schedule = schedule
 
-        self.args = task_args
-        self.kwargs = task_kwargs
+        self.args = args
+        self.kwargs = kwargs or {}
+        self.options = options or {}
+
+        self.last_run_at = last_run_at
+        self.total_run_count = total_run_count
 
         self.name = name
-        self.key = key
         self.rdb = StrictRedis.from_url(scheduler_url)
 
-        self.running = False
+        # storing extra arguments (might be useful to have other args depending on application)
+        for elem in extrakwargs.keys():
+            setattr(self, elem, extrakwargs[elem])
 
-    class Interval(object):
 
-        def __init__(self, every, period='seconds'):
-            self.every = every
-            # could be seconds minutes hours
-            self.period = period
-
-        def schedule(self, celery_schedules):
-            return celery_schedules.schedule(datetime.timedelta(**{self.period: self.every}))
-
-        @property
-        def period_singular(self):
-            return self.period[:-1]
-
-        def __unicode__(self):
-            if self.every == 1:
-                return 'every {0.period_singular}'.format(self)
-            return 'every {0.every} {0.period}'.format(self)
-
-    class Crontab(object):
-
-        def __init__(self, minute, hour, day_of_week, day_of_month, month_of_year):
-            self.minute = minute
-            self.hour = hour
-            self.day_of_week = day_of_week
-            self.day_of_month = day_of_month
-            self.month_of_year = month_of_year
-
-        def schedule(self, celery_schedules):
-            return celery_schedules.crontab(minute=self.minute,
-                                            hour=self.hour,
-                                            day_of_week=self.day_of_week,
-                                            day_of_month=self.day_of_month,
-                                            month_of_year=self.month_of_year)
-
-        def __unicode__(self):
-            rfield = lambda f: f and str(f).replace(' ', '') or '*'
-            return '{0} {1} {2} {3} {4} (m/h/d/dM/MY)'.format(
-                rfield(self.minute), rfield(self.hour), rfield(self.day_of_week),
-                rfield(self.day_of_month), rfield(self.month_of_year),
-            )
 
     @staticmethod
-    def get_all(scheduler_url, key_prefix):
+    def get_all_as_dict(scheduler_url, key_prefix):
         """get all of the tasks, for best performance with large amount of tasks, return a generator
         """
         rdb = StrictRedis.from_url(scheduler_url)
@@ -122,73 +164,113 @@ class PeriodicTask(object):
                 # task name should always correspond to the key in redis to avoid
                 # issues arising when saving keys - we want to add information to
                 # the current key, not create a new key
-                dct['key'] = task_key
-                yield dct
+                #dct['key'] = task_key  # TODO : maybe we can get rid of this ?
+                yield task_key, dct
             except json.JSONDecodeError:  # handling bad json format by ignoring the task
-                logger.warning('ERROR Reading task value at %s', task_key)
+                logger.warning('ERROR Reading json task at %s', task_key)
+
+    def _next_instance(self, last_run_at):
+        self.last_run_at = last_run_at
+        self.total_run_count += 1
+        """Return a new instance of the same class, but with
+        its date and count fields updated."""
+        return self.__class__(**dict(
+            self,
+            last_run_at=last_run_at,
+            total_run_count=self.total_run_count + 1,
+        ))
+    __next__ = next = _next_instance  # for 2to3
 
     def delete(self):
         self.rdb.delete(self.name)
 
-    def save(self):
-        # must do a deepcopy
-        self_dict = deepcopy({ k: v for k, v in self.__dict__.iteritems() if not isinstance(v, StrictRedis)})
-        if self_dict.get('interval'):
-            self_dict['interval'] = self.interval.__dict__
-        if self_dict.get('crontab'):
-            self_dict['crontab'] = self.crontab.__dict__
+    def save(self, key):
+        # must do a deepcopy using our custom iterator to choose what to save (matching external view)
+        self_dict = deepcopy({k: v for k, v in iter(self)})
+        self.rdb.set(key, json.dumps(self_dict, cls=DateTimeEncoder))
 
-        # remove the key from the dict so we don't save it into the redis
-        del self_dict['key']
-        self.rdb.set(self.key, json.dumps(self_dict, cls=DateTimeEncoder))
+    # def clean(self):
+    #     """validation to ensure that you have a schedule"""
+    #     if not (self.schedule):
+    #         msg = 'Must define a schedule.'
+    #         raise ValidationError(msg)
 
-    def clean(self):
-        """validation to ensure that you only have
-        an interval or crontab schedule, but not both simultaneously"""
-        if self.interval and self.crontab:
-            msg = 'Cannot define both interval and crontab schedule.'
-            raise ValidationError(msg)
-        if not (self.interval or self.crontab):
-            msg = 'Must defined either interval or crontab schedule.'
-            raise ValidationError(msg)
+    def update(self, other):
+        """Update values from another task.
 
-    @staticmethod
-    def from_dict(d, scheduler_url):
+        Does only update "editable" fields (task, schedule, args, kwargs,
+        options).
+
         """
-        build PeriodicTask instance from dict
-        :param d: dict
-        :return: PeriodicTask instance
-        """
-        if d.get('interval'):
-            schedule = PeriodicTask.Interval(d['interval']['every'], d['interval']['period'])
-        if d.get('crontab'):
-            schedule = PeriodicTask.Crontab(
-                d['crontab']['minute'],
-                d['crontab']['hour'],
-                d['crontab']['day_of_week'],
-                d['crontab']['day_of_month'],
-                d['crontab']['month_of_year']
-            )
-        task = PeriodicTask(scheduler_url, d['name'], d['task'], schedule, d['key'])
-        for elem in d:
-            if elem not in ('interval', 'crontab', 'schedule'):
-                setattr(task, elem, d[elem])
-        return task
+        self.__dict__.update({'task': other.task, 'schedule': other.schedule,
+                              'args': other.args, 'kwargs': other.kwargs,
+                              'options': other.options})
 
-    def schedule(self, celery_schedules):
-        if self.interval:
-            return self.interval.schedule(celery_schedules)
-        elif self.crontab:
-            return self.crontab.schedule(celery_schedules)
-        else:
-            raise Exception('must define interval or crontab schedule')
+    # @staticmethod
+    # def from_dict(d, scheduler_url):
+    #     """
+    #     build PeriodicTask instance from dict
+    #     :param d: dict
+    #     :return: PeriodicTask instance
+    #     """
+    #     # TODO : get rid of this, calling the constructor with **d should be enough
+    #     task = PeriodicTask(scheduler_url, d['name'], d['task'], d['schedule'], d['key'])
+    #     for elem in d:
+    #         if elem not in ('schedule'):
+    #             setattr(task, elem, d[elem])
+    #     return task
+    #
+    # def inject_celery(self, celery_schedules):
+    #         return self.schedule.schedule(celery_schedules)
+
+    def __repr__(self):
+        return '<PeriodicTask ({0} {1}(*{2}, **{3}) {{4}})>'.format(
+            self.name, self.task, self.args,
+            self.kwargs, self.schedule,
+        )
 
     def __unicode__(self):
-        fmt = '{0.name}: {{no schedule}}'
-        if self.interval:
-            fmt = '{0.name}: {0.interval}'
-        elif self.crontab:
-            fmt = '{0.name}: {0.crontab}'
-        else:
-            raise Exception('must define internal or crontab schedule')
+        fmt = '{0.name}: {0.schedule}'
         return fmt.format(self)
+
+    def get_schedule(self):
+        """
+        schedule Interval / Crontab -> dict
+        :return:
+        """
+        return vars(self.data)
+
+    def set_schedule(self, schedule):
+        """
+        schedule dict -> Interval / Crontab if needed
+        :return:
+        """
+        if isinstance(schedule, Interval) or isinstance(schedule, Crontab):
+            self.data = schedule
+        else:
+            schedule_inst = None
+            for s in [Interval, Crontab]:
+                try:
+                    schedule_inst = s(**schedule)
+                except TypeError as typexc:
+                    pass
+
+            if schedule_inst is None:
+                raise Exception(logger.warn("Schedule {s} didn't match Crontab or Interval type".format(s=schedule)))
+            else:
+                self.data = schedule_inst
+
+    schedule = property(get_schedule, set_schedule)
+
+    def __iter__(self):
+        """
+        We iterate on our members a little bit specially
+        => data is hidden and schedule is shown instead
+        => rdb is hidden
+        :return:
+        """
+        for k, v in vars(self).iteritems():
+            if k == 'data':
+                yield 'schedule', self.schedule
+            elif not k in ['rdb']:  # list the keys we don't want to expose
+                yield k, v

--- a/celerybeatredis/task.py
+++ b/celerybeatredis/task.py
@@ -63,27 +63,18 @@ class PeriodicTask(object):
     name = None
     task = None
 
-    type_ = None
-
     data = None
 
     args = []
     kwargs = {}
     options = {}
 
-    # datetime
-    expires = None
     enabled = True
 
     # datetime
     last_run_at = None
 
     total_run_count = 0
-
-    date_changed = None
-    description = None
-
-    no_changes = False
 
     # Follow celery.beat.SchedulerEntry:__init__() signature as much as possible
     def __init__(self, name, task, schedule, enabled=True, args=(), kwargs=None, options=None,
@@ -157,16 +148,13 @@ class PeriodicTask(object):
         """
         Update values from another task.
         This is used to dynamically update periodic task from edited redis values
-        Does only update "editable" fields (task, schedule, args, kwargs,
-        options).
+        Does not update "non-editable" fields (last_run_at, total_run_count).
+        Extra arguments will be updated (considered editable)
         """
-        # schedule/data is a bit of a special case
-        self.data = other.data
-
-        # do the rest
-        self.__dict__.update({'task': other.task, 'enabled': other.enabled,
-                              'args': other.args, 'kwargs': other.kwargs,
-                              'options': other.options})
+        otherdict = other.__dict__  # note : schedule property is not part of the dict.
+        otherdict.pop('last_run_at')
+        otherdict.pop('total_run_count')
+        self.__dict__.update(otherdict)
 
     def __repr__(self):
         return '<PeriodicTask ({0} {1}(*{2}, **{3}) options: {4} schedule: {5})>'.format(

--- a/celerybeatredis/task.py
+++ b/celerybeatredis/task.py
@@ -131,7 +131,7 @@ class PeriodicTask(object):
         for task_key in tasks:
             try:
                 dct = json.loads(rdb.get(task_key), cls=DateTimeDecoder)
-                logger.warning('json task {0}'.format(dct))
+                # logger.warning('json task {0}'.format(dct))
                 yield task_key, dct
             except json.JSONDecodeError:  # handling bad json format by ignoring the task
                 logger.warning('ERROR Reading json task at %s', task_key)

--- a/celerybeatredis/task.py
+++ b/celerybeatredis/task.py
@@ -169,9 +169,9 @@ class PeriodicTask(object):
                               'options': other.options})
 
     def __repr__(self):
-        return '<PeriodicTask ({0} {1}(*{2}, **{3}) {{4}})>'.format(
+        return '<PeriodicTask ({0} {1}(*{2}, **{3}) options: {4} schedule: {5})>'.format(
             self.name, self.task, self.args,
-            self.kwargs, self.schedule,
+            self.kwargs, self.options, self.schedule,
         )
 
     def __unicode__(self):


### PR DESCRIPTION
Although this is working for my usecase, it is probably not ready for merge yet.
It s a refactor I did mostly for simplicity and keeping the code close to celery 3.1 design regarding scheduler API, while following djcelery ideas regarding how to manage DB entries.

Feel free to let me know where you want this code (different branch maybe ?)
I think it still needs more time and testing before merging into master... but it would be very helpful to get someone else feedback on it.

Note : the lock functionality is not implemented here, but everything else should work AFAIK.
