### PR TITLE
Add back jsondump lost in merge of #16, and fix load predefined schedules

### DIFF
--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -254,6 +254,9 @@ class RedisScheduler(Scheduler):
         super(RedisScheduler, self).setup_schedule()
         # In case we have a preconfigured schedule
         self.update_from_dict(self.app.conf.CELERYBEAT_SCHEDULE)
+        for name in self.app.conf.CELERYBEAT_SCHEDULE:
+            if not self.rdb.get(name):
+                self.rdb.set(name, self.schedule[name].jsondump())
 
     def tick(self):
         """Run a tick, that is one iteration of the scheduler.


### PR DESCRIPTION
Two changes here:
- in https://github.com/kongluoxing/celerybeatredis/pull/16 there was a method `jsondump` added on `PeriodicTask`; seems like this was lost when that pr was merged, but it is still called from `RedisScheduler.sync`. 
- addresses https://github.com/kongluoxing/celerybeatredis/issues/1 -- what happens is that `Scheduler.merge_inplace` keeps only the union; which means anything that's not already in redis (like a schedule from the celery config) is lost. The easy solution is to just add them in redis on setup, but I'm not sure at all if it is the best approach. I'll be happy to update with a different approach if you prefer.
