### PR TITLE
add compatibility with celery4.

### DIFF
--- a/celerybeatredis/schedulers.py
+++ b/celerybeatredis/schedulers.py
@@ -4,27 +4,24 @@
 # Licensed under the Apache License, Version 2.0 (the 'License'); you may not
 # use this file except in compliance with the License. You may obtain a copy
 # of the License at http://www.apache.org/licenses/LICENSE-2.0
-import datetime
-import logging
-from functools import partial
-# we don't need simplejson, builtin json module is good enough
-import json
-from copy import deepcopy
 
-from celery.beat import Scheduler, ScheduleEntry
+from datetime import timedelta, datetime
+
+import celery
+from celery.beat import Scheduler
 from redis import StrictRedis
 from celery import current_app
 import kombu.utils
 import celery.schedules
 from redis.exceptions import LockError
 
-from .task import PeriodicTask
-from .exceptions import ValidationError, TaskTypeError
-from .decoder import DateTimeDecoder, DateTimeEncoder
-from .globals import logger
+from task import PeriodicTask
+from exceptions import TaskTypeError
+from globals import logger
 
 
 class RedisScheduleEntry(object):
+
     """
     The Schedule Entry class is mainly here to handle the celery dependency injection
      and delegates everything to a PeriodicTask instance
@@ -39,24 +36,34 @@ class RedisScheduleEntry(object):
 
         # defaults (MUST NOT call self here - or loop __getattr__ for ever)
         app = app or current_app
-        # Setting a default time a bit before now to not miss a task that was just added.
-        last_run_at = last_run_at or app.now() - datetime.timedelta(
+        # Setting a default time a bit before now to not miss a task that was
+        # just added.
+
+        if {'every', 'period'}.issubset(schedule.keys()):
+            now = self.nowfun()
+            # first time or system reboot
+            if not last_run_at or last_run_at > now:
+                last_run_at = now - timedelta(
+                    seconds=app.conf.CELERYBEAT_MAX_LOOP_INTERVAL)
+        elif not last_run_at:
+            last_run_at = app.now() - timedelta(
                 seconds=app.conf.CELERYBEAT_MAX_LOOP_INTERVAL)
 
         # using periodic task as delegate
         object.__setattr__(self, '_task', PeriodicTask(
-                # Note : for compatibiilty with celery methods, the name of the task is actually the key in redis DB.
-                # For extra fancy fields (like a human readable name, you can leverage extrakwargs)
-                name=name,
-                task=task,
-                enabled=enabled,
-                schedule=schedule,  # TODO : sensible default here ?
-                args=args,
-                kwargs=kwargs or {},
-                options=options or {},
-                last_run_at=last_run_at,
-                total_run_count=total_run_count or 0,
-                **extrakwargs
+            # Note : for compatibiilty with celery methods, the name of the task is actually the key in redis DB.
+            # For extra fancy fields (like a human readable name, you can
+            # leverage extrakwargs)
+            name=name,
+            task=task,
+            enabled=enabled,
+            schedule=schedule,  # TODO : sensible default here ?
+            args=args,
+            kwargs=kwargs or {},
+            options=options or {},
+            last_run_at=last_run_at,
+            total_run_count=total_run_count or 0,
+            **extrakwargs
         ))
 
         #
@@ -65,6 +72,14 @@ class RedisScheduleEntry(object):
 
         # The app is kept here (PeriodicTask should not need it)
         object.__setattr__(self, 'app', app)
+
+    @classmethod
+    def nowfun(cls, utc=True):
+        with open('/proc/uptime', 'r') as f:
+            uptime = float(f.readline().split()[0])
+        if utc:
+            return datetime.utcfromtimestamp(uptime)
+        return datetime.fromtimestamp(uptime)
 
     # automatic delegation to PeriodicTask (easy delegate)
     def __getattr__(self, attr):
@@ -77,8 +92,8 @@ class RedisScheduleEntry(object):
             return
         # else we raise
         raise AttributeError(
-                "Attribute {attr} not found in {tasktype}".format(attr=attr,
-                                                                  tasktype=type(self._task)))
+            "Attribute {attr} not found in {tasktype}".format(attr=attr,
+                                                              tasktype=type(self._task)))
 
     #
     # Overrides schedule accessors in PeriodicTask to store dict in json but retrieve proper celery schedules
@@ -86,17 +101,22 @@ class RedisScheduleEntry(object):
     def get_schedule(self):
         if {'every', 'period'}.issubset(self._task.schedule.keys()):
             return celery.schedules.schedule(
-                    datetime.timedelta(
-                        **{self._task.schedule['period']: self._task.schedule['every']}),
-                    self.app)
+                run_every=timedelta(**{self._task.schedule[
+                                    'period']: self._task.schedule['every']}),
+                nowfun=self.nowfun,
+                app=self.app)
         elif {'minute', 'hour', 'day_of_week', 'day_of_month', 'month_of_year'}.issubset(
                 self._task.schedule.keys()):
-            return celery.schedules.crontab(minute=self._task.schedule['minute'],
-                                            hour=self._task.schedule['hour'],
-                                            day_of_week=self._task.schedule['day_of_week'],
-                                            day_of_month=self._task.schedule['day_of_month'],
-                                            month_of_year=self._task.schedule['month_of_year'],
-                                            app=self.app)
+            return celery.schedules.crontab(
+                minute=self._task.schedule['minute'],
+                hour=self._task.schedule['hour'],
+                day_of_week=self._task.schedule[
+                    'day_of_week'],
+                day_of_month=self._task.schedule[
+                    'day_of_month'],
+                month_of_year=self._task.schedule[
+                    'month_of_year'],
+                app=self.app)
         else:
             raise TaskTypeError('Existing Task schedule type not recognized')
 
@@ -130,7 +150,8 @@ class RedisScheduleEntry(object):
 
         logger.debug('task {0} due : {1}'.format(self.name, due))
         if not self.enabled:
-            logger.info('task {0} is disabled. not triggered.'.format(self.name))
+            logger.info(
+                'task {0} is disabled. not triggered.'.format(self.name))
             # if the task is disabled, we always return false, but the time that
             # it is next due is returned as usual
             return celery.schedules.schedstate(is_due=False, next=due[1])
@@ -139,8 +160,11 @@ class RedisScheduleEntry(object):
 
     def __repr__(self):
         return '<RedisScheduleEntry: {0.name} {call} {0.schedule}'.format(
-                self,
-                call=kombu.utils.reprcall(self.task, self.args or (), self.kwargs or {}),
+            self,
+            call=kombu.utils.reprcall(
+                self.task,
+                self.args or (),
+                self.kwargs or {}),
         )
 
     def update(self, other):
@@ -167,9 +191,9 @@ class RedisScheduleEntry(object):
         """Return a new instance of the same class, but with
         its date and count fields updated."""
         return self.__class__(**dict(
-                self,
-                last_run_at=last_run_at or self._default_now(),
-                total_run_count=self.total_run_count + 1,
+            self,
+            last_run_at=last_run_at or self._default_now(),
+            total_run_count=self.total_run_count + 1,
         ))
 
     __next__ = next = _next_instance  # for 2to3
@@ -191,7 +215,8 @@ class RedisScheduleEntry(object):
     def from_entry(cls, scheduler_url, name, **entry):
         options = entry.get('options') or {}
         fields = dict(entry)
-        fields['name'] = current_app.conf.CELERY_REDIS_SCHEDULER_KEY_PREFIX + name
+        fields['name'] = current_app.conf.CELERY_REDIS_SCHEDULER_KEY_PREFIX + \
+            name
         schedule = fields.pop('schedule')
         schedule = celery.schedules.maybe_schedule(schedule)
         if isinstance(schedule, celery.schedules.crontab):
@@ -203,8 +228,9 @@ class RedisScheduleEntry(object):
                 'month_of_year': schedule._orig_month_of_year
             }
         elif isinstance(schedule, celery.schedules.schedule):
-            fields['interval'] = {'every': max(schedule.run_every.total_seconds(), 0),
-                                  'period': 'seconds'}
+            fields[
+                'interval'] = {'every': max(schedule.run_every.total_seconds(), 0),
+                               'period': 'seconds'}
 
         fields['args'] = fields.get('args', [])
         fields['kwargs'] = fields.get('kwargs', {})
@@ -223,8 +249,8 @@ class RedisScheduler(Scheduler):
             logger.info('backend scheduler using %s',
                         current_app.conf.CELERY_REDIS_SCHEDULER_URL)
 
-        self.update_interval = current_app.conf.get('UPDATE_INTERVAL') or datetime.timedelta(
-                seconds=10)
+        self.update_interval = current_app.conf.get('UPDATE_INTERVAL') or timedelta(
+            seconds=10)
 
         # how long we should hold on to the redis lock in seconds
         if 'CELERY_REDIS_SCHEDULER_LOCK_TTL' in current_app.conf:
@@ -236,16 +262,24 @@ class RedisScheduler(Scheduler):
             lock_ttl = self.update_interval.seconds * 2
         self.lock_ttl = lock_ttl
 
-        self._dirty = set()  # keeping modified entries by name for sync later on
+        # sync schedule to db when beat closed
+        self.save_entry_back = current_app.conf.get("REDIS_SAVE_ENTRY_BACK", "True")
+
+        # keeping modified entries by name for sync later on
+        self._dirty = set()
         self._schedule = {}  # keeping dynamic schedule from redis DB here
         # self.data is used for statically configured schedule
         self.schedule_url = current_app.conf.CELERY_REDIS_SCHEDULER_URL
         self.rdb = StrictRedis.from_url(self.schedule_url)
         self._last_updated = None
         self._lock_acquired = False
-        self._lock = self.rdb.lock('celery:beat:task_lock', timeout=self.lock_ttl)
+        self._lock = self.rdb.lock(
+            'celery:beat:task_lock',
+            timeout=self.lock_ttl)
         self._lock_acquired = self._lock.acquire(blocking=False)
         self.Entry.scheduler = self
+        self.old_task_dict = {}
+        self.heap_to_none = False
 
         # This will launch setup_schedule if not lazy
         super(RedisScheduler, self).__init__(*args, **kwargs)
@@ -263,19 +297,26 @@ class RedisScheduler(Scheduler):
         Executes all due tasks.
         """
         # need to grab all data (might have been updated) from schedule DB.
-        # we need to merge it with whatever schedule was set in config, and already installed default tasks
+        # we need to merge it with whatever schedule was set in config, and
+        # already installed default tasks
         try:
             s = self.all_as_schedule()
             self.merge_inplace(s)
         except Exception as exc:
             logger.error(
-                    "Exception when getting tasks from {url} : {exc}".format(url=self.schedule_url,
-                                                                             exc=exc))
+                "Exception when getting tasks from {url} : {exc}".format(url=self.schedule_url,
+                                                                         exc=exc))
             # TODO : atomic merge : be able to cancel it if there s a problem
             raise
 
         # displaying the schedule we got from redis
         logger.debug("DB schedule : {0}".format(self.schedule))
+
+        if celery.__version__ > "4":
+            if self.heap_to_none or not self._heap:
+                self.logger.debug("set heap to none")
+                self._heap = None
+                self.heap_to_none = False
 
         # this will call self.maybe_due() to check if any entry is due.
         return super(RedisScheduler, self).tick()
@@ -288,17 +329,30 @@ class RedisScheduler(Scheduler):
         d = {}
         for key, task in entry_class.get_all_as_dict(self.rdb, key_prefix):
             # logger.debug('Building {0} from : {1}'.format(entry_class, task))
+            if key not in self.old_task_dict or self.old_task_dict[key] != task:
+                self.old_task_dict[key] = task
+                self.heap_to_none = True
             d[key] = entry_class(**dict(task, app=self.app))
+        keys = self.old_task_dict.keys()
+        for i in keys:
+            if i not in d:
+                self.heap_to_none = True
+                del self.old_task_dict[i]
         return d
 
     def reserve(self, entry):
-        # called when the task is about to be run (and data will be modified -> sync() will need to save it)
+        # called when the task is about to be run (and data will be modified ->
+        # sync() will need to save it)
         new_entry = super(RedisScheduler, self).reserve(entry)
-        # Need to store the key of the entry, because the entry may change in the mean time.
+        # Need to store the key of the entry, because the entry may change in
+        # the mean time.
         self._dirty.add(new_entry.name)
         return new_entry
 
     def sync(self):
+        if not self.save_entry_back:
+            logger.info('Without save entry back to redis...')
+            return
         logger.info('Writing modified entries...')
         _tried = set()
         try:
@@ -306,7 +360,10 @@ class RedisScheduler(Scheduler):
                 name = self._dirty.pop()
                 _tried.add(name)
                 # Saving the entry back into Redis DB.
-                self.rdb.set(name, self.schedule[name].jsondump())
+                try:
+                    self.rdb.set(name, self.schedule[name].jsondump())
+                except KeyError:
+                    logger.warning("rdb key %s may be already removed." % name)
         except Exception as exc:
             # retry later
             self._dirty |= _tried
@@ -320,7 +377,8 @@ class RedisScheduler(Scheduler):
         self.sync()
 
     def __del__(self):
-        # celery beat will create Scheduler twice, first time create then destroy it, so we need release lock here
+        # celery beat will create Scheduler twice, first time create then
+        # destroy it, so we need release lock here
         try:
             self._lock.release()
         except LockError:


### PR DESCRIPTION
pep8 schedules.py and task.py
add switcher REDIS_SAVE_ENTRY_BACK(True by default), sync schedule to db when beat closed.
Fixes the periodic task can not be performed as expected due to system time changes.